### PR TITLE
Enable SignUp view to create multiple account from same installation

### DIFF
--- a/app/javascript/dashboard/routes/auth/auth.routes.js
+++ b/app/javascript/dashboard/routes/auth/auth.routes.js
@@ -12,7 +12,7 @@ export default {
       path: frontendURL('auth/signup'),
       name: 'auth_signup',
       component: Signup,
-      meta: { requireSignupEnabled: true },
+      meta: { requireSignupEnabled: false },
     },
     {
       path: frontendURL('auth'),


### PR DESCRIPTION
## Description

This change is required to set requireSignupEnabled: false so we can create and configure new accounts from UI.


