### PR TITLE
Feature 

### DIFF
--- a/app/javascript/widget/assets/scss/views/_conversation.scss
+++ b/app/javascript/widget/assets/scss/views/_conversation.scss
@@ -222,6 +222,10 @@
     max-width: 100%;
   }
 
+  &.has-attachment {
+    padding: 0;
+  }
+
   >a {
     color: $color-primary;
     word-break: break-all;

--- a/app/javascript/widget/components/FileBubble.vue
+++ b/app/javascript/widget/components/FileBubble.vue
@@ -86,6 +86,7 @@ export default {
 @import '~widget/assets/scss/variables.scss';
 
 .file {
+  padding: $space-slab $space-normal !important;  
   .icon-wrap {
     font-size: $font-size-mega;
     color: $color-woot;

--- a/app/javascript/widget/components/ImageBubble.vue
+++ b/app/javascript/widget/components/ImageBubble.vue
@@ -53,7 +53,7 @@ export default {
       );
       bottom: 0;
       content: '';
-      height: 20%;
+      height: 16%;
       left: 0;
       opacity: 0.8;
       position: absolute;

--- a/app/javascript/widget/components/UserMessage.vue
+++ b/app/javascript/widget/components/UserMessage.vue
@@ -14,7 +14,6 @@
         <div
           v-if="hasAttachments"
           class="chat-bubble has-attachment user"
-          :style="{ backgroundColor: widgetColor }"
         >
           <div v-for="attachment in message.attachments" :key="attachment.id">
             <image-bubble
@@ -29,6 +28,7 @@
               :url="attachment.data_url"
               :is-in-progress="isInProgress"
               :widget-color="widgetColor"
+              :style="{ backgroundColor: widgetColor }"
               is-user-bubble
             />
           </div>


### PR DESCRIPTION
# Pull Request Template

<details>
<summary>New images box</summary>

![image](https://user-images.githubusercontent.com/9289461/220175343-7af45281-c9d0-4c52-bdc8-206c2d618e92.png)
</details>

<details>
<summary>Previous/ chatwood images box</summary>

![image](https://user-images.githubusercontent.com/9289461/220178557-917d75ae-0545-4017-97a3-56e790c68bab.png)


</details>

## Description

-This PR aims just to remove the background color from the chatwood widget and change it to transparent (this due to PNG images which were taking chatwood widget color)
- This PR also aims to remove image box padding, and leave it just for the image (Borders will be kept as they are)
- File and text should not be affected

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Run Chatwood [Locally](https://www.notion.so/apli/Chatwoot-local-configuration-bce491eb472a433ca3ec629b0d34844a)
- Send images and check new border and padding styles are applied
- Also test with videos, images, docs (just to verify these haven't been affected)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
