### PR TITLE
Feature | UI Enhancement -> Center chat view over ipad and desktop

### DIFF
--- a/app/javascript/widget/assets/scss/_variables.scss
+++ b/app/javascript/widget/assets/scss/_variables.scss
@@ -79,4 +79,4 @@ $font-family: 'Inter', -apple-system, system-ui, BlinkMacSystemFont, 'Segoe UI',
 
 // Break points
 $break-point-medium: 667px;
-$break-point-ipad: 800px;
+$break-point-tablet: 800px;

--- a/app/javascript/widget/assets/scss/_variables.scss
+++ b/app/javascript/widget/assets/scss/_variables.scss
@@ -79,3 +79,4 @@ $font-family: 'Inter', -apple-system, system-ui, BlinkMacSystemFont, 'Segoe UI',
 
 // Break points
 $break-point-medium: 667px;
+$break-point-ipad: 800px;

--- a/app/javascript/widget/components/ChatFooter.vue
+++ b/app/javascript/widget/components/ChatFooter.vue
@@ -134,10 +134,8 @@ export default {
 @import '~widget/assets/scss/variables.scss';
 
 .footer-chat {
-  @media screen and (min-width: $break-point-ipad) {
-    width: $break-point-ipad;
-    margin: 0 auto;
-  }
+  max-width: $break-point-tablet;
+  margin: 0 auto;
 }
 
 .branding {

--- a/app/javascript/widget/components/ChatFooter.vue
+++ b/app/javascript/widget/components/ChatFooter.vue
@@ -1,7 +1,7 @@
 <template>
   <footer
     v-if="!hideReplyBox"
-    class="shadow-sm bg-white mb-1 z-50 relative"
+    class="footer-chat shadow-sm bg-white mb-1 z-50 relative w-full"
     :class="{ 'rounded-lg': !isWidgetStyleFlat }"
   >
     <chat-input-wrap
@@ -132,6 +132,13 @@ export default {
 </script>
 <style scoped lang="scss">
 @import '~widget/assets/scss/variables.scss';
+
+.footer-chat {
+  @media screen and (min-width: 800px) {
+    width: 50%;
+    margin: 0 auto;
+  }
+}
 
 .branding {
   align-items: center;

--- a/app/javascript/widget/components/ChatFooter.vue
+++ b/app/javascript/widget/components/ChatFooter.vue
@@ -134,8 +134,8 @@ export default {
 @import '~widget/assets/scss/variables.scss';
 
 .footer-chat {
-  @media screen and (min-width: 800px) {
-    width: 50%;
+  @media screen and (min-width: $break-point-ipad) {
+    width: $break-point-ipad;
     margin: 0 auto;
   }
 }

--- a/app/javascript/widget/components/ChatHeader.vue
+++ b/app/javascript/widget/components/ChatHeader.vue
@@ -1,6 +1,6 @@
 <template>
   <header
-    class="flex justify-between p-5 w-full"
+    class="header-wrap flex justify-between p-5 w-full"
     :class="$dm('bg-white', 'dark:bg-slate-900')"
   >
     <div class="flex items-center">
@@ -106,3 +106,12 @@ export default {
   },
 };
 </script>
+
+<style scoped lang="scss">
+.header-wrap {
+  @media screen and (min-width: 800px) {
+    width: 50%;
+    margin: 0 auto;
+  }
+}
+</style>

--- a/app/javascript/widget/components/ChatHeader.vue
+++ b/app/javascript/widget/components/ChatHeader.vue
@@ -111,9 +111,7 @@ export default {
 @import 'widget/assets/scss/variables';
 
 .header-wrap {
-  @media screen and (min-width: $break-point-ipad) {
-    width: $break-point-ipad;
-    margin: 0 auto;
-  }
+  max-width: $break-point-tablet;
+  margin: 0 auto;
 }
 </style>

--- a/app/javascript/widget/components/ChatHeader.vue
+++ b/app/javascript/widget/components/ChatHeader.vue
@@ -108,9 +108,11 @@ export default {
 </script>
 
 <style scoped lang="scss">
+@import 'widget/assets/scss/variables';
+
 .header-wrap {
-  @media screen and (min-width: 800px) {
-    width: 50%;
+  @media screen and (min-width: $break-point-ipad) {
+    width: $break-point-ipad;
     margin: 0 auto;
   }
 }

--- a/app/javascript/widget/components/ConversationWrap.vue
+++ b/app/javascript/widget/components/ConversationWrap.vue
@@ -128,6 +128,10 @@ export default {
 .conversation-wrap {
   flex: 1;
   padding: $space-large $space-small $space-small $space-small;
+  @media screen and (min-width: 800px) {
+    width: 50%;
+    margin: 0 auto;
+  }
 }
 
 .message--loader {

--- a/app/javascript/widget/components/ConversationWrap.vue
+++ b/app/javascript/widget/components/ConversationWrap.vue
@@ -128,10 +128,9 @@ export default {
 .conversation-wrap {
   flex: 1;
   padding: $space-large $space-small $space-small $space-small;
-  @media screen and (min-width: $break-point-ipad) {
-    width: $break-point-ipad;
-    margin: 0 auto;
-  }
+  max-width: $break-point-tablet;
+  margin: 0 auto;
+  width: 100%;
 }
 
 .message--loader {

--- a/app/javascript/widget/components/ConversationWrap.vue
+++ b/app/javascript/widget/components/ConversationWrap.vue
@@ -128,8 +128,8 @@ export default {
 .conversation-wrap {
   flex: 1;
   padding: $space-large $space-small $space-small $space-small;
-  @media screen and (min-width: 800px) {
-    width: 50%;
+  @media screen and (min-width: $break-point-ipad) {
+    width: $break-point-ipad;
     margin: 0 auto;
   }
 }

--- a/app/javascript/widget/components/layouts/ViewWithHeader.vue
+++ b/app/javascript/widget/components/layouts/ViewWithHeader.vue
@@ -5,7 +5,7 @@
     @keydown.esc="closeWindow"
   >
     <div
-      class="header-wrap"
+      class="header-wrap bg-white"
       :class="{
         expanded: !isHeaderCollapsed,
         collapsed: isHeaderCollapsed,


### PR DESCRIPTION
# Pull Request Template

<details>
<summary>New Chat viewx</summary>

![image](https://user-images.githubusercontent.com/9289461/220638785-ab749fbc-a3d3-4b4b-b330-78b535c0173c.png)
</details>

<details>
<summary>Previous/ chatwood view less than 800px</summary>

![image](https://user-images.githubusercontent.com/9289461/220638987-bdce7543-e170-4fa1-b706-55c4afb8ea5a.png)


</details>

## Description

-This PR aims just to center chat window view, all elements must be centered

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Run Chatwood [Locally](https://www.notion.so/apli/Chatwoot-local-configuration-bce491eb472a433ca3ec629b0d34844a)
- Verify new chat view is centered (header, conversation body, footer input msg)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules