### PR TITLE
Feature || UI Enhancement -> Modify FileBubble text decoration

### DIFF
--- a/app/javascript/widget/components/FileBubble.vue
+++ b/app/javascript/widget/components/FileBubble.vue
@@ -103,10 +103,10 @@ export default {
   .download {
     color: $color-woot;
     font-weight: $font-weight-medium;
-    padding: 0;
+    padding: 2px 0 0 0;
     margin: 0;
     font-size: $font-size-small;
-    text-decoration: none;
+    text-decoration: underline;
   }
 
   .link-wrap {

--- a/app/javascript/widget/components/FileBubble.vue
+++ b/app/javascript/widget/components/FileBubble.vue
@@ -4,9 +4,6 @@
       <fluent-icon icon="document" size="28" />
     </div>
     <div class="meta">
-      <div class="title" :class="titleColor" :style="{ color: textColor }">
-        {{ title }}
-      </div>
       <div class="link-wrap mb-1">
         <a
           class="download"
@@ -15,6 +12,9 @@
           :style="{ color: textColor }"
           :href="url"
         >
+          <div class="title" :class="titleColor" :style="{ color: textColor }">
+            {{ title }}
+          </div>
           {{ $t('COMPONENTS.FILE_BUBBLE.DOWNLOAD') }}
         </a>
       </div>
@@ -95,18 +95,18 @@ export default {
   }
 
   .title {
+    text-decoration: underline;
     font-weight: $font-weight-medium;
     font-size: $font-size-default;
-    margin: 0;
+    margin: 0 0 4px 0;
   }
 
   .download {
     color: $color-woot;
     font-weight: $font-weight-medium;
-    padding: 2px 0 0 0;
     margin: 0;
     font-size: $font-size-small;
-    text-decoration: underline;
+    text-decoration: none;
   }
 
   .link-wrap {


### PR DESCRIPTION
# Pull Request Template

<details>
<summary>New File Bubble</summary>

![image](https://user-images.githubusercontent.com/9289461/220648700-f064ab5e-df98-46d9-9448-89eb8528e549.png)
</details>


## Description

-This PR aims just to add text-decoration: underline to the file uploaded 'Download button' in the chat. Also to change document icon to a solid one

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Run Chatwood [Locally](https://www.notion.so/apli/Chatwoot-local-configuration-bce491eb472a433ca3ec629b0d34844a)
- Upload a file


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
