### PR TITLE
Feature | Add Quick Replies to Vuex state

### DIFF
--- a/app/javascript/shared/components/ChatOption.vue
+++ b/app/javascript/shared/components/ChatOption.vue
@@ -1,20 +1,23 @@
 <template>
-  <li
+  <div
     class="option"
-    :class="{ 'is-selected': isSelected }"
-    :style="{ borderColor: widgetColor }"
+    :class="optionClass"
+    :style="{ borderColor: widgetColor, color: widgetColor }"
   >
     <button class="option-button button" @click="onClick">
       <span :style="{ color: widgetColor }">{{ action.title }}</span>
     </button>
-  </li>
+  </div>
 </template>
 
 <script>
 import { mapGetters } from 'vuex';
+import { getContrastingTextColor } from '@chatwoot/utils';
+import darkModeMixin from 'widget/mixins/darkModeMixin.js';
 
 export default {
   components: {},
+  mixins: [darkModeMixin],
   props: {
     action: {
       type: Object,
@@ -29,6 +32,14 @@ export default {
     ...mapGetters({
       widgetColor: 'appConfig/getWidgetColor',
     }),
+    textColor() {
+      return getContrastingTextColor(this.widgetColor);
+    },
+    optionClass() {
+      let optionClass = `${this.$dm('bg-white', 'dark:bg-slate-700')}`;
+      if (this.isSelected) optionClass = 'is-selected ' + optionClass;
+      return optionClass;
+    },
   },
   methods: {
     onClick() {
@@ -40,11 +51,12 @@ export default {
 
 <style scoped lang="scss">
 @import '~widget/assets/scss/variables.scss';
+@import '~widget/assets/scss/mixins.scss';
 
 .option {
+  @include light-shadow;
   border-radius: $space-jumbo;
   border: 1px solid $color-woot;
-  float: left;
   margin: $space-smaller;
   max-width: 100%;
 
@@ -62,6 +74,8 @@ export default {
     span {
       display: inline-block;
       vertical-align: middle;
+      font-weight: $font-weight-bold;
+      white-space: nowrap;
     }
 
     > .icon {

--- a/app/javascript/shared/components/ChatOptions.vue
+++ b/app/javascript/shared/components/ChatOptions.vue
@@ -7,70 +7,24 @@
       <h4 class="title" :class="$dm('text-black-900', 'dark:text-slate-50')">
         {{ title }}
       </h4>
-      <ul
-        v-if="!hideFields"
-        class="options"
-        :class="{ 'has-selected': !!selected }"
-      >
-        <chat-option
-          v-for="option in options"
-          :key="option.id"
-          :action="option"
-          :is-selected="isSelected(option)"
-          @click="onClick"
-        />
-      </ul>
     </div>
   </div>
 </template>
 
 <script>
-import ChatOption from 'shared/components/ChatOption';
 import darkModeMixin from 'widget/mixins/darkModeMixin.js';
 
 export default {
-  components: {
-    ChatOption,
-  },
   mixins: [darkModeMixin],
   props: {
     title: {
       type: String,
       default: '',
     },
-    options: {
-      type: Array,
-      default: () => [],
-    },
-    selected: {
-      type: String,
-      default: '',
-    },
-    hideFields: {
-      type: Boolean,
-      default: false,
-    },
-  },
-  methods: {
-    isSelected(option) {
-      return this.selected === option.id;
-    },
-    onClick(selectedOption) {
-      this.$emit('click', selectedOption);
-    },
   },
 };
 </script>
 
-<style lang="scss">
-@import '~dashboard/assets/scss/variables.scss';
-.has-selected {
-  .option-button:not(.is-selected) {
-    color: $color-light-gray;
-    cursor: initial;
-  }
-}
-</style>
 <style scoped lang="scss">
 @import '~widget/assets/scss/variables.scss';
 
@@ -86,15 +40,6 @@ export default {
     margin-top: $space-smaller;
     margin-bottom: $space-smaller;
     line-height: 1.5;
-  }
-
-  .options {
-    width: 100%;
-
-    > li {
-      list-style: none;
-      padding: 0;
-    }
   }
 }
 </style>

--- a/app/javascript/widget/components/AgentMessageBubble.vue
+++ b/app/javascript/widget/components/AgentMessageBubble.vue
@@ -25,12 +25,7 @@
       />
     </div>
     <div v-if="isOptions">
-      <chat-options
-        :title="message"
-        :options="messageContentAttributes.items"
-        :hide-fields="!!messageContentAttributes.submitted_values"
-        @click="onOptionSelect"
-      />
+      <chat-options :title="message" />
     </div>
     <chat-form
       v-if="isForm && !messageContentAttributes.submitted_values"
@@ -61,6 +56,7 @@
 </template>
 
 <script>
+import { mapMutations } from 'vuex';
 import messageFormatterMixin from 'shared/mixins/messageFormatterMixin';
 import ChatCard from 'shared/components/ChatCard';
 import ChatForm from 'shared/components/ChatForm';
@@ -118,8 +114,21 @@ export default {
     isIntegrations() {
       return this.contentType === 'integrations';
     },
+    hasResponse() {
+      return Boolean(this.messageContentAttributes.submitted_values);
+    },
+  },
+  mounted() {
+    if (this.isOptions && !this.hasResponse) {
+      this.setOptions(this.messageContentAttributes.items);
+      this.setCallback(this.onOptionSelect);
+    }
   },
   methods: {
+    ...mapMutations({
+      setOptions: 'conversation/setQuickRepliesOptions',
+      setCallback: 'conversation/setQuickRepliesCallback',
+    }),
     onResponse(messageResponse) {
       this.$store.dispatch('message/update', messageResponse);
     },
@@ -128,6 +137,7 @@ export default {
         submittedValues: [selectedOption],
         messageId: this.messageId,
       });
+      this.setOptions([]);
     },
     onFormSubmit(formValues) {
       const formValuesAsArray = Object.keys(formValues).map(key => ({

--- a/app/javascript/widget/components/ChatFooter.vue
+++ b/app/javascript/widget/components/ChatFooter.vue
@@ -31,7 +31,7 @@
 </template>
 
 <script>
-import { mapActions, mapGetters } from 'vuex';
+import { mapActions, mapGetters, mapMutations } from 'vuex';
 import { getContrastingTextColor } from '@chatwoot/utils';
 import CustomButton from 'shared/components/Button';
 import ChatInputWrap from 'widget/components/ChatInputWrap.vue';
@@ -57,6 +57,7 @@ export default {
       conversationSize: 'conversation/getConversationSize',
       currentUser: 'contacts/getCurrentUser',
       isWidgetStyleFlat: 'appConfig/isWidgetStyleFlat',
+      quickRepliesOptions: 'conversation/getQuickRepliesOptions',
     }),
     textColor() {
       return getContrastingTextColor(this.widgetColor);
@@ -87,6 +88,9 @@ export default {
       'getAttributes',
       'clearConversationAttributes',
     ]),
+    ...mapMutations({
+      setQuickRepliesOptions: 'conversation/setQuickRepliesOptions',
+    }),
     async handleSendMessage(content) {
       await this.sendMessage({
         content,
@@ -94,6 +98,10 @@ export default {
       // Update conversation attributes on new conversation
       if (this.conversationSize === 0) {
         this.getAttributes();
+      }
+      // Clear quick replies options in case the user ignores the quick replies
+      if (this.quickRepliesOptions.length) {
+        this.setQuickRepliesOptions([]);
       }
     },
     handleSendAttachment(attachment) {

--- a/app/javascript/widget/components/QuickReplies.vue
+++ b/app/javascript/widget/components/QuickReplies.vue
@@ -1,0 +1,95 @@
+<template>
+  <div v-if="isVisible" class="quick-replies" :class="classObject">
+    <chat-option
+      v-for="option in options"
+      :key="option.id"
+      :action="option"
+      :is-selected="isSelected(option)"
+      @click="onClick"
+    />
+  </div>
+</template>
+
+<script>
+import { mapGetters } from 'vuex';
+import ChatOption from 'shared/components/ChatOption';
+import darkModeMixin from 'widget/mixins/darkModeMixin.js';
+
+export default {
+  components: {
+    ChatOption,
+  },
+  mixins: [darkModeMixin],
+  props: {
+    isVisible: { type: Boolean, default: false },
+  },
+  data() {
+    let width = document.documentElement.clientWidth;
+    return { width };
+  },
+  computed: {
+    ...mapGetters({
+      options: 'conversation/getQuickRepliesOptions',
+      onOptionSelect: 'conversation/getQuickRepliesCallback',
+    }),
+    isMobile() {
+      return this.width < 668;
+    },
+    classObject() {
+      return { 'mobile-quick-replies': this.isMobile };
+    },
+  },
+  mounted() {
+    window.addEventListener('resize', this.getDimensions);
+  },
+  unmounted() {
+    window.removeEventListener('resize', this.getDimensions);
+  },
+  methods: {
+    getDimensions() {
+      this.width = document.documentElement.clientWidth;
+    },
+    isSelected(option) {
+      return this.selected === option.id;
+    },
+    onClick(selectedOption) {
+      this.onOptionSelect(selectedOption);
+    },
+  },
+};
+</script>
+
+<style scoped lang="scss">
+@import '~widget/assets/scss/variables.scss';
+
+.quick-replies {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  padding: 20px 20px 0 20px;
+  max-width: $break-point-tablet;
+  margin: 0 auto;
+}
+
+.mobile-quick-replies {
+  justify-content: unset;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+
+  /* Hide scrollbar for IE, Edge and Firefox */
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+
+  /* Hide scrollbar for Chrome, Safari and Opera */
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
+  .option:first-child {
+    margin-left: auto !important;
+  }
+}
+</style>

--- a/app/javascript/widget/store/modules/conversation/getters.js
+++ b/app/javascript/widget/store/modules/conversation/getters.js
@@ -51,4 +51,6 @@ export const getters = {
     const maxUnreadCount = Math.min(unreadCount, 3);
     return unreadAgentMessages.splice(-maxUnreadCount);
   },
+  getQuickRepliesOptions: _state => _state.quickReplies.options,
+  getQuickRepliesCallback: _state => _state.quickReplies.callback,
 };

--- a/app/javascript/widget/store/modules/conversation/index.js
+++ b/app/javascript/widget/store/modules/conversation/index.js
@@ -4,6 +4,10 @@ import { mutations } from './mutations';
 
 const state = {
   conversations: {},
+  quickReplies: {
+    options: [],
+    callback: undefined,
+  },
   meta: {
     userLastSeenAt: undefined,
   },

--- a/app/javascript/widget/store/modules/conversation/mutations.js
+++ b/app/javascript/widget/store/modules/conversation/mutations.js
@@ -94,4 +94,10 @@ export const mutations = {
   setMetaUserLastSeenAt($state, lastSeen) {
     $state.meta.userLastSeenAt = lastSeen;
   },
+  setQuickRepliesOptions($state, options) {
+    $state.quickReplies.options = options;
+  },
+  setQuickRepliesCallback($state, callback) {
+    $state.quickReplies.callback = callback;
+  },
 };

--- a/app/javascript/widget/views/Messages.vue
+++ b/app/javascript/widget/views/Messages.vue
@@ -3,7 +3,8 @@
     <div class="flex flex-1 overflow-auto">
       <conversation-wrap :grouped-messages="groupedMessages" />
     </div>
-    <div class="px-5 pb-5">
+    <quick-replies :is-visible="hasQuickRepliesOptions" />
+    <div class="px-5 py-5">
       <chat-footer />
     </div>
   </div>
@@ -12,13 +13,18 @@
 import { mapGetters } from 'vuex';
 import ChatFooter from '../components/ChatFooter.vue';
 import ConversationWrap from '../components/ConversationWrap.vue';
+import QuickReplies from '../components/QuickReplies.vue';
 
 export default {
-  components: { ChatFooter, ConversationWrap },
+  components: { ChatFooter, ConversationWrap, QuickReplies },
   computed: {
     ...mapGetters({
       groupedMessages: 'conversation/getGroupedConversation',
+      quickRepliesOptions: 'conversation/getQuickRepliesOptions',
     }),
+    hasQuickRepliesOptions() {
+      return Boolean(this.quickRepliesOptions.length);
+    },
   },
   mounted() {
     this.$store.dispatch('conversation/setUserLastSeen');


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1d98ZlYcTMLGAQ0G9Lvl6lf9Bp2dnS7IY%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=yLFzzgD)

## Description

- Update the store object to handle the quick replies state
- Add getters for options and callback
- Add mutations for options and callback

## How to test it?

There is nothing to test in this PR, since it doesn't affect anything. In the following PRs we will use this change to handle the interactive messages
