### PR TITLE
Feature | Responsiveness to `Start Conversation` screen

### DIFF
--- a/app/javascript/widget/components/ChatHeaderExpanded.vue
+++ b/app/javascript/widget/components/ChatHeaderExpanded.vue
@@ -1,6 +1,6 @@
 <template>
   <header
-    class="header-expanded py-6 px-5 relative box-border w-full"
+    class="header-expanded header-responsive py-6 px-5 relative box-border w-full"
     :class="$dm('bg-white', 'dark:bg-slate-900')"
   >
     <div
@@ -64,3 +64,12 @@ export default {
   },
 };
 </script>
+
+<style scoped lang="scss">
+@import '~widget/assets/scss/variables.scss';
+
+.header-responsive {
+  max-width: $break-point-tablet;
+  margin: 0 auto;
+}
+</style>

--- a/app/javascript/widget/components/TeamAvailability.vue
+++ b/app/javascript/widget/components/TeamAvailability.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="px-5 pb-5">
+  <div class="px-5 pb-5 responsive-container">
     <div class="flex items-center justify-between mb-4">
       <div
         class="max-w-xs"
@@ -94,3 +94,13 @@ export default {
   },
 };
 </script>
+
+<style scoped lang="scss">
+@import '~widget/assets/scss/variables.scss';
+
+.responsive-container {
+  max-width: $break-point-tablet;
+  margin: 0 auto;
+  width: 100%;
+}
+</style>


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1Lijy56WIPLBDyYk8PpwN6Ghnvb8f5uJ4%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=hQ57Jch)
## Media

<details><summary><b>New behavior</b></summary><br>

![Screenshot 2023-03-03 at 12 39 09](https://user-images.githubusercontent.com/22230419/222800997-ec0af649-edb9-43e4-b7d3-0ed319866220.png)

</details> 

## Description

As a continuation from PR #7, the home screen required responsiveness fixes too, to match the behavior implemented in that PR