### PR TITLE
Feature || add sentry release version with put parameter

### DIFF
--- a/.github/actions/deployment/push-image-ecr/action.yml
+++ b/.github/actions/deployment/push-image-ecr/action.yml
@@ -25,6 +25,10 @@ inputs:
     description: "Path where the Dockerfile is stored"
     required: true
 
+  SSM_VUE_APP_VERSION:
+    description: "SSM Parameter name for environment variable deploy commit hash"
+    required: false
+
 runs:
   using: 'composite'
   steps:
@@ -37,6 +41,12 @@ runs:
         aws-access-key-id: ${{ inputs.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ inputs.AWS_SECRET_ACCESS_KEY }}
         aws-region: us-east-1
+
+    - name: Set Vue app version 
+      if: ${{ input.SSM_VUE_APP_VERSION != '' }}
+      shell: bash
+      run: 
+        aws ssm put-parameter --name ${{input.SSM_VUE_APP_VERSION}} --value $(git rev-parse --short HEAD)
     
     - name: Login to Amazon ECR
       id: login-ecr

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -24,6 +24,7 @@ jobs:
           ECR_REGISTRY: 663605677942.dkr.ecr.us-east-1.amazonaws.com
           ECR_REPOSITORY: conversations/birdwoot/production/birdwootmain
           DOCKERFILE_PATH: docker/Dockerfile
+          SSM_VUE_APP_VERSION: /conversations/birdwoot/production/taskdefinition/environment/vue-app-version
       
       - name: Build and publish Docker image into AWS ECR for Sidekiq
         uses: ./.github/actions/deployment/push-image-ecr

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -24,6 +24,7 @@ jobs:
           ECR_REGISTRY: 823532849758.dkr.ecr.us-east-1.amazonaws.com
           ECR_REPOSITORY: conversations/birdwoot/staging/birdwootmain
           DOCKERFILE_PATH: docker/Dockerfile
+          SSM_VUE_APP_VERSION: /conversations/birdwoot/staging/taskdefinition/environment/vue-app-version
       
       - name: Build and publish Docker image into AWS ECR for Sidekiq
         uses: ./.github/actions/deployment/push-image-ecr


### PR DESCRIPTION
## Description

We need Sentry release version to be the deploy commit hash, as this value is dynamic it must be updated by github actions, and in this way, it can be updated on the environment variables in was ecs. 

- Add SSM_VUE_APP_VERSION input in `action.yml` to hold the last commit hash
- Add this input reference in the `deploy-staging.yml `and `deploy-staging.yml` workflows
- Set this value only for Birdwoot. 


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

This should be tested in staging 


