### PR TITLE
Feature || apm config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -167,9 +167,14 @@ USE_INBOX_AVATAR_FOR_BOT=true
 ## https://www.elastic.co/guide/en/apm/agent/ruby/current/getting-started-rails.html
 # ELASTIC_APM_SERVER_URL=
 # ELASTIC_APM_SECRET_TOKEN=
+## Elastic APM JS RUM
+#VUE_APP_APM_RUM_SERVER_URL=
 
 ## Sentry
 # SENTRY_DSN=
+#VUE_APP_SENTRY_DSN_CHAT=
+#VUE_APP_SENTRY_DSN_DASHBOARD=
+
 
 ## LogRocket
 # LOG_ROCKET_PROJECT_ID=xxxxx/some-project

--- a/app/javascript/apm/index.js
+++ b/app/javascript/apm/index.js
@@ -1,0 +1,17 @@
+import { init as initApm } from '@elastic/apm-rum';
+
+if (process.env.NODE_ENV !== 'development') {
+  initApm({
+    // Set required service name (allowed characters: a-z, A-Z, 0-9, -, _, and space)
+    serviceName: 'birdwoot',
+
+    // Set custom APM Server URL (default: http://localhost:8200)
+    serverUrl: process.env.VUE_APP_APM_RUM_SERVER_URL,
+
+    // Set the service version (required for source map feature)
+    serviceVersion: process.env.VUE_APP_VERSION,
+
+    // Set the service environment
+    environment: process.env.NODE_ENV,
+  });
+}


### PR DESCRIPTION
Description
Add the configuration for support of elastic apm monitoring in Birdwoot.

How to test?
Unfortunately, connection to elastic apm can only be configured through the server, this means locally running versions cant connect. So we have to perform a deploy to staging in order to test that everything is working ok.