### PR TITLE
Add type to AWS SSM put-parameter action

### DIFF
--- a/.github/actions/deployment/push-image-ecr/action.yml
+++ b/.github/actions/deployment/push-image-ecr/action.yml
@@ -46,7 +46,7 @@ runs:
       if: ${{ inputs.SSM_VUE_APP_VERSION != '' }}
       shell: bash
       run: 
-        aws ssm put-parameter --name ${{inputs.SSM_VUE_APP_VERSION}} --value $(git rev-parse --short HEAD)
+        aws ssm put-parameter --name ${{inputs.SSM_VUE_APP_VERSION}} --value $(git rev-parse --short HEAD) --type "SecureString"
     
     - name: Login to Amazon ECR
       id: login-ecr


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX19YdU5EtdKAzjUXeTYxoLDsg1E8kNDdEdo%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=oZjhpX6)

Add `type` flag because the deployment workflow is crashing