### PR TITLE
Feature || remove prev env vars config

### DIFF
--- a/app/javascript/widget/store/modules/conversation/actions.js
+++ b/app/javascript/widget/store/modules/conversation/actions.js
@@ -2,6 +2,7 @@ import {
   createConversationAPI,
   sendMessageAPI,
   getMessagesAPI,
+  sendAttachmentAPI,
   toggleTyping,
   setUserLastSeenAt,
   toggleStatus,
@@ -68,7 +69,12 @@ export const actions = {
     });
     commit('pushMessageToConversation', tempMessage);
     try {
-      throw new Error('Testing Sentry errors in staging gor sendAttachment');
+      const { data } = await sendAttachmentAPI(params);
+      commit('updateAttachmentMessageStatus', {
+        message: data,
+        tempId: tempMessage.id,
+      });
+      commit('pushMessageToConversation', { ...data, status: 'sent' });
     } catch (error) {
       captureSentryException(error);
       commit('pushMessageToConversation', { ...tempMessage, status: 'failed' });

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -79,8 +79,6 @@ services:
       - WEBPACKER_DEV_SERVER_HOST=0.0.0.0
       - NODE_ENV=development
       - RAILS_ENV=development
-      - VUE_APP_VERSION=test_webpack_docker_compose
-      - VUE_APP_SENTRY_DSN_CHAT=https://02b9c03c61e642228cd22016b7ce452d@o59321.ingest.sentry.io/4504889702023168
     entrypoint: docker/entrypoints/webpack.sh
     command: bin/webpack-dev-server
 

--- a/docker/dockerfiles/webpack.Dockerfile
+++ b/docker/dockerfiles/webpack.Dockerfile
@@ -3,7 +3,4 @@ FROM chatwoot:development
 RUN chmod +x docker/entrypoints/webpack.sh
 
 EXPOSE 3035
-ENV VUE_APP_VERSION="test_webpack_dockerfile"
-ENV VUE_APP_SENTRY_DSN_CHAT="https://02b9c03c61e642228cd22016b7ce452d@o59321.ingest.sentry.io/4504889702023168"
-
 CMD ["bin/webpack-dev-server"]


### PR DESCRIPTION
## Description

This PR removes prev environment variables configuration and also the harcoded `throw Error` as it was just for testing purposes 