### PR TITLE
Introducing Sidekiq Health Check endpoint to rails

### DIFF
--- a/app/controllers/sidekiq_health_check_controller.rb
+++ b/app/controllers/sidekiq_health_check_controller.rb
@@ -1,0 +1,15 @@
+class SidekiqHealthCheckController < ActionController
+  def check
+    res = `ps -ef | grep -i sidekiq | wc -l`
+    res = res.strip
+    if res.to_i < 2
+      render json: {
+        error: 'sidekiq is not running'
+      }, status: :internal_server_error and return
+    end
+
+    render json: {
+      message: 'sidekiq is running'
+    }, status: :ok and return
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,8 @@
 Rails.application.routes.draw do
+  if ActiveModel::Type::Boolean.new.cast(ENV.fetch('SIDEKIQ_HEALTH_CHECK_ONLY_SERVER', false))
+    get '/sidekiq_health_check', to: 'sidekiq_health_check#check'
+    return
+  end
   # AUTH STARTS
   mount_devise_token_auth_for 'User', at: 'auth', controllers: {
     confirmations: 'devise_overrides/confirmations',


### PR DESCRIPTION
## Description

This change is required to enable a health check for sidekiq worker service, so it can be deployed as a separate ECS task behind a load balancer for auto scaling.
As a rule of thumb, load balancers requires to execute a health check thru http / https request to an endpoint that returns 200 status code.
This new controller is looking for sidekiq process to be running, otherwise it will return internal server error status code.

As follow up tasks It is still required to:
- disable existing mailers and rails endpoints that kept enabled for rails server even after establishing SIDEKIQ_HEALTH_CHECK_ONLY_SERVER=true
- Remove rails global dependency to database active connection, as it is not required for this standalone health check endpoint.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Local http request to /sidekiq_health_check endpoint:
![image](https://user-images.githubusercontent.com/100155261/233219335-d5f2e324-6041-45b8-b3a3-2894928fc718.png)



## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
