### PR TITLE
Feature || try dotEnv configuration

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -53,6 +53,8 @@ development:
   <<: *default
   compile: true
 
+  plugins:
+    - dotenv-webpack
   # Verifies that correct packages and versions are installed by inspecting package.json, yarn.lock, and node_modules
   check_yarn_integrity: true
 
@@ -87,6 +89,9 @@ test:
 
 production:
   <<: *default
+
+  plugins:
+    - dotenv-webpack
 
   # Production depends on precompilation of packs prior to booting for performance.
   compile: false

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "babel-loader": "8.2.2",
     "babel-preset-vue": "^2.0.2",
     "cypress": "4.12.1",
+    "dotenv-webpack": "^8.0.1",
     "eslint": "^6.8.0",
     "eslint-config-airbnb-base": "14.2.1",
     "eslint-config-prettier": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7347,15 +7347,34 @@ dot-prop@^5.2.0:
   dependencies:
     is-obj "^2.0.0"
 
+dotenv-defaults@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/dotenv-defaults/-/dotenv-defaults-2.0.2.tgz#6b3ec2e4319aafb70940abda72d3856770ee77ac"
+  integrity sha512-iOIzovWfsUHU91L5i8bJce3NYK5JXeAwH50Jh6+ARUdLiiGlYWfGw6UkzsYqaXZH/hjE/eCd/PlfM/qqyK0AMg==
+  dependencies:
+    dotenv "^8.2.0"
+
 dotenv-expand@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-5.1.0.tgz#3fbaf020bfd794884072ea26b1e9791d45a629f0"
   integrity sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==
 
+dotenv-webpack@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/dotenv-webpack/-/dotenv-webpack-8.0.1.tgz#6656550460a8076fab20e5ac2eac867e72478645"
+  integrity sha512-CdrgfhZOnx4uB18SgaoP9XHRN2v48BbjuXQsZY5ixs5A8579NxQkmMxRtI7aTwSiSQcM2ao12Fdu+L3ZS3bG4w==
+  dependencies:
+    dotenv-defaults "^2.0.2"
+
 dotenv@^8.0.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
   integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
+
+dotenv@^8.2.0:
+  version "8.6.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.6.0.tgz#061af664d19f7f4d8fc6e4ff9b584ce237adcb8b"
+  integrity sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==
 
 dset@^3.0.0, dset@^3.1.1:
   version "3.1.2"


### PR DESCRIPTION
## Description

As we are using @rails/webpacker it seems that dotEnv must be configured so that Environment Variables are passed correctly to the container, other way they are undefined... This is the first PR just to verify if this configuration is correct. 
