### PR TITLE
Security | Adding CORS domain restriction based on webwidget url and widget filtering

### DIFF
--- a/app/controllers/widgets_controller.rb
+++ b/app/controllers/widgets_controller.rb
@@ -9,6 +9,7 @@ class WidgetsController < ActionController::Base
   before_action :set_token
   before_action :set_contact
   before_action :build_contact
+  before_action :check_domain
   after_action :allow_iframe_requests
 
   private
@@ -22,6 +23,13 @@ class WidgetsController < ActionController::Base
   rescue ActiveRecord::RecordNotFound
     Rails.logger.error('web widget does not exist')
     render json: { error: 'web widget does not exist' }, status: :not_found
+  end
+
+  def check_domain
+    return if request.base_url.downcase.start_with? @web_widget.website_url.downcase
+
+    Rails.logger.error('web widget does not match with expected domain')
+    render json: { error: 'web widget does not match with expected domain' }, status: :not_found
   end
 
   def set_token

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,18 +1,58 @@
 # config/initializers/cors.rb
 # ref: https://github.com/cyu/rack-cors
 
-# font cors issue with CDN
-# Ref: https://stackoverflow.com/questions/56960709/rails-font-cors-policy
-Rails.application.config.middleware.insert_before 0, Rack::Cors do
-  allow do
-    origins '*'
-    resource '/packs/*', headers: :any, methods: [:get, :options]
-    resource '/audio/*', headers: :any, methods: [:get, :options]
-    # Make the public endpoints accessible to the frontend
-    resource '/public/api/*', headers: :any, methods: :any
+# rubocop:disable Rails/ApplicationRecord
+class WebWidget < ActiveRecord::Base
+  self.table_name = 'channel_web_widgets'
+end
+# rubocop:enable Rails/ApplicationRecord
 
-    if ActiveModel::Type::Boolean.new.cast(ENV.fetch('CW_API_ONLY_SERVER', false)) || Rails.env.development?
-      resource '*', headers: :any, methods: :any, expose: %w[access-token client uid expiry]
+unless ENV.fetch('FRONTEND_URL', nil).nil?
+  Rails.application.config.middleware.insert_before 0, Rack::Cors do
+    allow do
+      origins ENV.fetch('FRONTEND_URL', '')
+      resource '/packs/*', headers: :any, methods: [:get, :options]
+      resource '/audio/*', headers: :any, methods: [:get, :options]
+      # Make the public endpoints accessible to the frontend
+      resource '/public/api/*', headers: :any, methods: :any
+
+      if ActiveModel::Type::Boolean.new.cast(ENV.fetch('CW_API_ONLY_SERVER', false)) || Rails.env.development?
+        resource '*', headers: :any, methods: :any, expose: %w[access-token client uid expiry]
+      end
+    end
+  end
+end
+
+if ENV.fetch('CORS_WIDGET_CONFIG', true)
+  WebWidget.all.each do |widget|
+    # font cors issue with CDN
+    # Ref: https://stackoverflow.com/questions/56960709/rails-font-cors-policy
+    Rails.application.config.middleware.insert_before 0, Rack::Cors do
+      allow do
+        origins widget.website_url
+        resource '/packs/*', headers: :any, methods: [:get, :options]
+        resource '/audio/*', headers: :any, methods: [:get, :options]
+        # Make the public endpoints accessible to the frontend
+        resource '/public/api/*', headers: :any, methods: :any
+
+        if ActiveModel::Type::Boolean.new.cast(ENV.fetch('CW_API_ONLY_SERVER', false)) || Rails.env.development?
+          resource '*', headers: :any, methods: :any, expose: %w[access-token client uid expiry]
+        end
+      end
+    end
+  end
+else
+  Rails.application.config.middleware.insert_before 0, Rack::Cors do
+    allow do
+      origins '*'
+      resource '/packs/*', headers: :any, methods: [:get, :options]
+      resource '/audio/*', headers: :any, methods: [:get, :options]
+      # Make the public endpoints accessible to the frontend
+      resource '/public/api/*', headers: :any, methods: :any
+
+      if ActiveModel::Type::Boolean.new.cast(ENV.fetch('CW_API_ONLY_SERVER', false)) || Rails.env.development?
+        resource '*', headers: :any, methods: :any, expose: %w[access-token client uid expiry]
+      end
     end
   end
 end


### PR DESCRIPTION
## Description

This is required to avoid allowing web plugin to be executed from insecure / unexpected destinations.
https://github.com/aplijobs/birdwoot/issues/50

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested locally
![image](https://github.com/aplijobs/birdwoot/assets/100155261/2b29086c-9648-432d-bf46-6f88fe0cb6cf)


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
