### PR TITLE
Feature | Quick Replies with images

### DIFF
--- a/app/javascript/shared/components/ChatOption.vue
+++ b/app/javascript/shared/components/ChatOption.vue
@@ -5,7 +5,7 @@
     :style="{ borderColor: widgetColor, color: widgetColor }"
   >
     <button class="option-button button" @click="onClick">
-      <span v-if="action.image_url" class="icon"><img :src="action.image_url"/></span>
+      <span v-if="action.image_url" class="icon"><img :src="action.image_url" alt="icon" /></span>
       <span :style="{ color: widgetColor }">{{ action.title }}</span>
     </button>
   </div>


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1PxLPGVsdsThs0V5aq87qpFGSs2FmToA%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=_XfRBB_)

## Media

![Screenshot 2023-05-29 at 17 44 35](https://github.com/aplijobs/birdwoot/assets/22230419/7688986b-feff-4650-89ce-35a2b8ab6b2d) 

## Description

As a request from product team, we were requested to add the option that quick replies can display images. So quick replies can render images, if the info object doesn't have any `image_url` nothing happens, the quick reply will render the text only 👍🏼 

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Without backend changes implemented, we can test it adding this code in the file `app/javascript/widget/components/QuickReplies.vue` in `mounted` function

```
this.setOptions([
      {
        title: 'Yes',
        value: 'yes',
        image_url: 'https://cdnlll.apli.chat/assets/images/bot/72/yes.png',
      },
      {
        title: 'No',
        value: 'no',
        image_url: 'https://cdnlll.apli.chat/assets/images/bot/72/no.png',
      },
	 {
        title: 'Maybe',
        value: 'maybe',
      },
])
```

also we have to import the mutation, so inside `methods` section add the following

```
...mapMutations({
      setOptions: 'conversation/setQuickRepliesOptions',
    }),
```

 don't forget to `import {mapMutations} from vuex`  ⚠️ 
 
## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
