### PR TITLE
Feature | Force online status

### DIFF
--- a/app/javascript/widget/components/ChatHeader.vue
+++ b/app/javascript/widget/components/ChatHeader.vue
@@ -23,18 +23,13 @@
           :class="$dm('text-black-900', 'dark:text-slate-50')"
         >
           <span v-dompurify-html="title" class="mr-1" />
-          <div
-            :class="
-              `h-2 w-2 rounded-full leading-4
-              ${isOnline ? 'bg-green-500' : 'hidden'}`
-            "
-          />
+          <div class="h-2 w-2 rounded-full leading-4 bg-green-500" />
         </div>
         <div
           class="text-xs mt-1"
           :class="$dm('text-black-700', 'dark:text-slate-400')"
         >
-          {{ replyWaitMessage }}
+          {{ $t('TEAM_AVAILABILITY.ONLINE') }}
         </div>
       </div>
     </div>

--- a/app/javascript/widget/components/TeamAvailability.vue
+++ b/app/javascript/widget/components/TeamAvailability.vue
@@ -6,11 +6,7 @@
         :class="$dm('text-black-700', 'dark:text-slate-50')"
       >
         <div class="text-base leading-5 font-medium mb-1">
-          {{
-            isOnline
-              ? $t('TEAM_AVAILABILITY.ONLINE')
-              : $t('TEAM_AVAILABILITY.OFFLINE')
-          }}
+          {{ $t('TEAM_AVAILABILITY.ONLINE') }}
         </div>
         <div class="text-xs leading-4 mt-1">
           {{ replyWaitMessage }}

--- a/app/javascript/widget/i18n/locale/en.json
+++ b/app/javascript/widget/i18n/locale/en.json
@@ -17,6 +17,7 @@
     "OFFLINE": "We are away at the moment"
   },
   "REPLY_TIME": {
+    "INSTANTLY": "Typically replies instantly",
     "IN_A_FEW_MINUTES": "Typically replies in a few minutes",
     "IN_A_FEW_HOURS": "Typically replies in a few hours",
     "IN_A_DAY": "Typically replies in a day",

--- a/app/javascript/widget/i18n/locale/es.json
+++ b/app/javascript/widget/i18n/locale/es.json
@@ -17,6 +17,7 @@
     "OFFLINE": "Estamos ausentes en este momento"
   },
   "REPLY_TIME": {
+    "INSTANTLY": "Normalmente responde de inmediato",
     "IN_A_FEW_MINUTES": "Normalmente responde en unos minutos",
     "IN_A_FEW_HOURS": "Normalmente responde en unas pocas horas",
     "IN_A_DAY": "Normalmente responde en un día"

--- a/app/javascript/widget/mixins/availability.js
+++ b/app/javascript/widget/mixins/availability.js
@@ -28,9 +28,7 @@ export default {
           ? this.replyTimeStatus
           : `${this.$t('REPLY_TIME.BACK_IN')} ${this.timeLeftToBackInOnline}`;
       }
-      return this.isOnline
-        ? this.replyTimeStatus
-        : this.$t('TEAM_AVAILABILITY.OFFLINE');
+      return this.$t('REPLY_TIME.INSTANTLY')
     },
     outOfOfficeMessage() {
       return this.channelConfig.outOfOfficeMessage;


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1dcifD0z2NX9ZgZrO9TiJS2IY0G3c8%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=CsP8y4R)

## Media

![Screenshot 2023-05-30 at 19 08 12](https://github.com/aplijobs/birdwoot/assets/22230419/a2133e59-f015-4971-b725-63a093d3cb52)

![Screenshot 2023-06-01 at 12 35 39](https://github.com/aplijobs/birdwoot/assets/22230419/99fb2989-fb55-4341-8ebf-4fd9b82aec43)


## Description

As a request from the product team, we are forcing to show the bot as online always. This change was done with the i18n resources already created in chatwoot, and we force to show the green dot indicator too.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Just run Birdwoot locally and the change must be applied immediatly 

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
