### PR TITLE
Feature | Introduce `only_path` for Attachment Model

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -51,7 +51,7 @@ class Attachment < ApplicationRecord
 
   # NOTE: the URl returned does a 301 redirect to the actual file
   def file_url
-    file.attached? ? rails_blob_path(file, only_path: true) : ''
+    file.attached? ? url_for(file) : ''
   end
 
   # NOTE: for External services use this methods since redirect doesn't work effectively in a lot of cases

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -51,7 +51,7 @@ class Attachment < ApplicationRecord
 
   # NOTE: the URl returned does a 301 redirect to the actual file
   def file_url
-    file.attached? ? url_for(file) : ''
+    file.attached? ? url_for(file, only_path: true) : ''
   end
 
   # NOTE: for External services use this methods since redirect doesn't work effectively in a lot of cases

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -51,7 +51,7 @@ class Attachment < ApplicationRecord
 
   # NOTE: the URl returned does a 301 redirect to the actual file
   def file_url
-    file.attached? ? url_for(file, only_path: true) : ''
+    file.attached? ? rails_blob_path(file, only_path: true) : ''
   end
 
   # NOTE: for External services use this methods since redirect doesn't work effectively in a lot of cases

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -35,6 +35,7 @@ Rails.application.configure do
   config.active_job.queue_adapter = :sidekiq
 
   Rails.application.routes.default_url_options = { host: ENV['FRONTEND_URL'] }
+  config.action_mailer.default_url_options = { :host => ENV['FRONTEND_URL'] }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -103,4 +103,5 @@ Rails.application.configure do
   config.action_mailbox.ingress = ENV.fetch('RAILS_INBOUND_EMAIL_SERVICE', 'relay').to_sym
 
   Rails.application.routes.default_url_options = { host: ENV['FRONTEND_URL'] }
+  config.action_mailer.default_url_options = { :host => ENV['FRONTEND_URL'] }
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -51,6 +51,7 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "chatwoot_#{Rails.env}"
 
   Rails.application.routes.default_url_options = { host: ENV['FRONTEND_URL'] }
+  config.action_mailer.default_url_options = { :host => ENV['FRONTEND_URL'] }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).


### PR DESCRIPTION
## Description

Trying to fix issue when uploading images on production.

<img width="1137" alt="Screenshot 2023-06-26 at 13 10 00" src="https://github.com/aplijobs/birdwoot/assets/40701972/8996f31e-c853-4a57-aeb9-e725431d9813">

<img width="1123" alt="Screenshot 2023-06-26 at 13 10 37" src="https://github.com/aplijobs/birdwoot/assets/40701972/7a264e1e-9fff-49cb-b3ff-38c38209a13e">

Reference: https://stackoverflow.com/questions/7219732/rails-missing-host-to-link-to-please-provide-host-parameter-or-set-default-ur

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Nope.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
