### PR TITLE
Enhancement | Change hover effect on Quick Replies

### DIFF
--- a/app/javascript/shared/components/ChatOption.vue
+++ b/app/javascript/shared/components/ChatOption.vue
@@ -60,13 +60,11 @@ export default {
   border: 1px solid $color-woot;
   margin: $space-smaller;
   max-width: 100%;
+  transform: translateY(0px);
 
   &:hover {
     @include normal-shadow;
-
-    span {
-      font-weight: $font-weight-bold;
-    }
+    transform: translateY(-2px);
   }
 
   .option-button {


### PR DESCRIPTION
## Media

<details><summary><b>Issue</b></summary><br>

https://github.com/aplijobs/birdwoot/assets/22230419/d8195a4c-42ac-4605-8844-fd6b1abcae37

</details> 

<details><summary><b>Fixed behavior</b></summary><br>

https://github.com/aplijobs/birdwoot/assets/22230419/61a6e284-9e60-40dc-ade6-0f95b2b9ee8a

</details> 

## Description

There was an edge case that causes an issue with the quick replies UX. What was happening is that the hover effect made affected the option border and font-weight, causing a change in the item size. Since the item grows a little bit, the wrap functionality of the flex container causes the last element in the row to be moved to the next row, making it impossible to click that option in particular.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Just needed to add some quick replies options to the local store and test their hover behavior 🚀 

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
