### PR TITLE
Enhancement | Move Quick Replies to Scrollable container

### DIFF
--- a/app/javascript/widget/components/ConversationWrap.vue
+++ b/app/javascript/widget/components/ConversationWrap.vue
@@ -21,6 +21,7 @@
         />
       </div>
       <agent-typing-bubble v-if="isAgentTyping" />
+      <quick-replies :is-visible="hasQuickRepliesOptions" />
     </div>
   </div>
 </template>
@@ -29,6 +30,7 @@
 import ChatMessage from 'widget/components/ChatMessage.vue';
 import AgentTypingBubble from 'widget/components/AgentTypingBubble.vue';
 import DateSeparator from 'shared/components/DateSeparator.vue';
+import QuickReplies from 'widget/components/QuickReplies.vue';
 import Spinner from 'shared/components/Spinner.vue';
 import darkModeMixin from 'widget/mixins/darkModeMixin';
 
@@ -41,6 +43,7 @@ export default {
     AgentTypingBubble,
     DateSeparator,
     Spinner,
+    QuickReplies
   },
   mixins: [darkModeMixin],
   props: {
@@ -62,9 +65,13 @@ export default {
       isFetchingList: 'conversation/getIsFetchingList',
       conversationSize: 'conversation/getConversationSize',
       isAgentTyping: 'conversation/getIsAgentTyping',
+      quickRepliesOptions: 'conversation/getQuickRepliesOptions',
     }),
     colorSchemeClass() {
       return `${this.darkMode === 'dark' ? 'dark-scheme' : 'light-scheme'}`;
+    },
+    hasQuickRepliesOptions() {
+      return Boolean(this.quickRepliesOptions.length);
     },
   },
   watch: {

--- a/app/javascript/widget/views/Messages.vue
+++ b/app/javascript/widget/views/Messages.vue
@@ -3,7 +3,6 @@
     <div class="flex flex-1 overflow-auto">
       <conversation-wrap :grouped-messages="groupedMessages" />
     </div>
-    <quick-replies :is-visible="hasQuickRepliesOptions" />
     <div class="px-5 py-5">
       <chat-footer />
     </div>
@@ -13,18 +12,13 @@
 import { mapGetters } from 'vuex';
 import ChatFooter from '../components/ChatFooter.vue';
 import ConversationWrap from '../components/ConversationWrap.vue';
-import QuickReplies from '../components/QuickReplies.vue';
 
 export default {
-  components: { ChatFooter, ConversationWrap, QuickReplies },
+  components: { ChatFooter, ConversationWrap },
   computed: {
     ...mapGetters({
       groupedMessages: 'conversation/getGroupedConversation',
-      quickRepliesOptions: 'conversation/getQuickRepliesOptions',
     }),
-    hasQuickRepliesOptions() {
-      return Boolean(this.quickRepliesOptions.length);
-    },
   },
   mounted() {
     this.$store.dispatch('conversation/setUserLastSeen');


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1nFqBdax3FtrDm5X1xol422p5tAvQZA%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=_VO-2fj)

## Media

<details><summary><b>Video</b></summary><br>

https://github.com/aplijobs/birdwoot/assets/22230419/084e08ff-1a39-4c27-bdd2-686925ff26b6

</details> 


## Description

As a request from the product team, we were asked to move the Quick Replies container to the scrollable container in the chat window.

## Type of change

- [X] New feature (non-breaking change which adds functionality)


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
