### PR TITLE
Enhancement | Clear unanswered quick replies when new message arrives

### DIFF
--- a/app/javascript/widget/store/modules/conversation/actions.js
+++ b/app/javascript/widget/store/modules/conversation/actions.js
@@ -148,8 +148,13 @@ export const actions = {
     commit('clearConversations');
   },
 
-  addOrUpdateMessage: async ({ commit }, data) => {
+  addOrUpdateMessage: async ({ commit, state }, data) => {
     const { id, content_attributes } = data;
+    const { quickReplies } = state;
+    // If there are quick replies active, remove them before showing the new message
+    if (quickReplies.options.length > 0) {
+      commit('setQuickRepliesOptions', []);
+    }
     if (content_attributes && content_attributes.deleted) {
       commit('deleteMessage', id);
       return;


### PR DESCRIPTION
## Description

Undesired scenario:
- A send template message arrives with a set of quick replies for the user
- The user doesn't select any option
- A new message arrives without quick replies
- The previous quick replies options remain visible although there are from the previous message that is not valid anymore

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## Media

<details><summary><b>Video</b></summary><br>

https://github.com/aplijobs/birdwoot/assets/22230419/bb80f39f-261f-4f37-b69e-61c22cbb937f

</details> 


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
