### PR TITLE
Removed Alpine repository for vips

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,8 +18,6 @@ ENV NODE_OPTIONS ${NODE_OPTIONS}
 
 ENV BUNDLE_PATH="/gems"
 
-RUN apk add --update --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/main vips
-
 RUN apk update && apk add --no-cache \
     openssl \
     tar \
@@ -96,8 +94,6 @@ ENV BUNDLE_FORCE_RUBY_PLATFORM ${BUNDLE_FORCE_RUBY_PLATFORM}
 ARG RAILS_ENV=production
 ENV RAILS_ENV ${RAILS_ENV}
 ENV BUNDLE_PATH="/gems"
-
-RUN apk add --update --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/main vips
 
 RUN apk update && apk add --no-cache \
   build-base \


### PR DESCRIPTION
## Why is this change necessary?

Apparently, there's been an issue with inconsistency between shared object libraries in the Alpine distribution and other dependencies required for this project. It's difficult to pinpoint the exact dependency that causes this, but previous Docker builds throw an error similar to this one:

```
...[omitted logs]
#7 24.98 Executing gdk-pixbuf-2.42.10-r6.trigger
#7 24.98 Error relocating /usr/lib/libgio-2.0.so.0: statx: symbol not found
#7 24.98 Error relocating /lib/libmount.so.1: statx: symbol not found
#7 24.98 ERROR: gdk-pixbuf-2.42.10-r6.trigger: script exited with error 127
...[omitted logs]
```

This seems to be a recurring issue with other repositories that use Alpine. Examples:
- https://github.com/gramineproject/gramine/issues/1836
- https://github.com/sparklemotion/sqlite3-ruby/issues/434

## How does this solve the issue?

Since `vips` appears to be included in the specified Docker image distribution, we will use the default repository instead of `http://dl-3.alpinelinux.org/alpine/edge/main`.