### PR TITLE
Feature | Delete "cache" after exiting conversation

### DIFF
--- a/app/javascript/widget/components/ChatFooter.vue
+++ b/app/javascript/widget/components/ChatFooter.vue
@@ -108,22 +108,10 @@ export default {
       this.sendAttachment({ attachment });
     },
     startNewConversation() {
-      console.log('entra al start conversation del footer')
-      const ref1 = new URLSearchParams(window.location.search).get('referral');
-      console.log('ref desde chat footer al inicio', ref1)
       this.clearConversations();
       this.clearConversationAttributes();
       this.setQuickRepliesOptions([]);
-      const ref2 = new URLSearchParams(window.location.search).get('referral');
-      console.log('ref desde chat footer', ref2)
-      if (ref) {
-        this.$store.dispatch('conversation/createConversation', {});
-      };
-      if (this.preChatFormEnabled && !this.conversationSize) {
-        return this.replaceRoute('prechat-form');
-      }
-      return this.replaceRoute('messages');
-      console.log('entra al start conversation del footer y termina toda la ejecucion')
+      this.$store.dispatch('conversation/createConversation', {});
     },
     async sendTranscript() {
       const { email } = this.currentUser;

--- a/app/javascript/widget/views/Home.vue
+++ b/app/javascript/widget/views/Home.vue
@@ -48,7 +48,6 @@ export default {
   methods: {
     startConversation() {
       const ref = new URLSearchParams(window.location.search).get('referral');
-      console.log('ref desde home', ref)
       if (ref) {
         this.$store.dispatch('conversation/createConversation', {});
       }


### PR DESCRIPTION
## Description

We got this issue reported from product, in which exiting the conversation was keeping the same conversation and not starting a new one. So this PR aims to solve this [issue](https://apli.slack.com/archives/C056S4HAX50/p1739980017091299) 


## Type of change

We add the same behaviour that chatwoot has when starting a new conversation. 

## How Has This Been Tested?

Tested in local. 
Please test this in develop