### PR TITLE
ci: rename default branch to main and switch deploy to manual trigger

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -1,9 +1,6 @@
 name: Deploy Production
 
 on:
-  push:
-    branches: 
-      - trunk
   workflow_dispatch:
   
   
@@ -18,7 +15,7 @@ jobs:
       - name: Build and publish Docker image into AWS ECR for Birdwoot
         uses: ./.github/actions/deployment/push-image-ecr
         with:
-          BRANCH: trunk
+          BRANCH: main
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_PRODUCTION }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_PRODUCTION }}
           ECR_REGISTRY: 663605677942.dkr.ecr.us-east-1.amazonaws.com
@@ -29,7 +26,7 @@ jobs:
       - name: Build and publish Docker image into AWS ECR for Sidekiq
         uses: ./.github/actions/deployment/push-image-ecr
         with:
-          BRANCH: trunk
+          BRANCH: main
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_PRODUCTION }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_PRODUCTION }}
           ECR_REGISTRY: 663605677942.dkr.ecr.us-east-1.amazonaws.com


### PR DESCRIPTION
## Summary
- Rename default branch from `trunk` to `main`
- Switch production deploy from automatic push trigger to manual (`workflow_dispatch`)