### PR TITLE
feat: Add message origin to outgoing payload

### DIFF
--- a/app/builders/messages/message_builder.rb
+++ b/app/builders/messages/message_builder.rb
@@ -133,9 +133,10 @@ class Messages::MessageBuilder
   end
 
   def additional_attributes_from_params
-    return {} if @params[:additional_attributes].blank?
+    source = content_attributes[:source]
+    return {} if source.blank?
 
-    { additional_attributes: @params[:additional_attributes].to_h }
+    { additional_attributes: { source: source } }
   end
 
   def message_sender

--- a/app/builders/messages/message_builder.rb
+++ b/app/builders/messages/message_builder.rb
@@ -133,10 +133,11 @@ class Messages::MessageBuilder
   end
 
   def additional_attributes_from_params
-    source = content_attributes[:source]
-    return {} if source.blank?
+    source_type = content_attributes[:source_type]
+    source_name = content_attributes[:source_name]
+    return {} if source_type.blank? && source_name.blank?
 
-    { additional_attributes: { source: source } }
+    { additional_attributes: { source_type: source_type, source_name: source_name }.compact }
   end
 
   def message_sender

--- a/app/builders/messages/message_builder.rb
+++ b/app/builders/messages/message_builder.rb
@@ -132,6 +132,12 @@ class Messages::MessageBuilder
     @params[:template_params].present? ? { additional_attributes: { template_params: JSON.parse(@params[:template_params].to_json) } } : {}
   end
 
+  def additional_attributes_from_params
+    return {} if @params[:additional_attributes].blank?
+
+    { additional_attributes: @params[:additional_attributes].to_h }
+  end
+
   def message_sender
     return if @params[:sender_type] != 'AgentBot'
 
@@ -151,6 +157,6 @@ class Messages::MessageBuilder
       in_reply_to: @in_reply_to,
       echo_id: @params[:echo_id],
       source_id: @params[:source_id]
-    }.merge(external_created_at).merge(automation_rule_id).merge(campaign_id).merge(template_params)
+    }.merge(external_created_at).merge(automation_rule_id).merge(campaign_id).merge(template_params).merge(additional_attributes_from_params)
   end
 end


### PR DESCRIPTION
## Description
This PR receives new fields in the incoming payload related to the origin of the message (bot/human) and adds the data to the outgoing payload that is sent to the conversation listener, so we can recognize the source of the message.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
By sending a message to a Birdwoot conversation, then checking conversation listener logs. The result is the following:
<img width="889" height="172" alt="Captura de pantalla 2026-03-24 a la(s) 13 19 33" src="https://github.com/user-attachments/assets/f502b4f9-4123-4cde-b88b-f9b64c1d7e7d" />


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
