### PR TITLE
ci: disable automatic production deployment

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -17,6 +17,12 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     steps:
+      - name: Validate confirmation
+        run: |
+          if [[ "${{ inputs.confirm }}" != "deploy" ]]; then
+            echo "ERROR: You must type exactly \"deploy\" to confirm. Got: \"${{ inputs.confirm }}\""
+            exit 1
+          fi
       - name: Checkout code
         uses: actions/checkout@v3
 

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -2,8 +2,16 @@ name: Deploy Production
 
 on:
   workflow_dispatch:
-  
-  
+    inputs:
+      reason:
+        description: 'Deployment reason (ticket, release note, etc.)'
+        required: true
+        type: string
+      confirm:
+        description: 'Type "deploy" to confirm production deployment'
+        required: true
+        type: string
+
 
 jobs:
   build-and-push:

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -18,9 +18,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate confirmation
+        env:
+          CONFIRM: ${{ inputs.confirm }}
         run: |
-          if [[ "${{ inputs.confirm }}" != "deploy" ]]; then
-            echo "ERROR: You must type exactly \"deploy\" to confirm. Got: \"${{ inputs.confirm }}\""
+          if [[ "$CONFIRM" != "deploy" ]]; then
+            echo "ERROR: You must type exactly \"deploy\" to confirm. Got: \"$CONFIRM\""
             exit 1
           fi
       - name: Checkout code


### PR DESCRIPTION
## Summary

  This PR disables automatic deployments to production triggered by direct pushes to production branches (master, main, trunk).

  All affected production workflows have been updated to require a manual trigger (workflow_dispatch) with explicit inputs, preventing unintended deployments on merge.

## Changes

  - Removed push branch trigger from all production deployment workflows
  - Added workflow_dispatch with required inputs:
    - reason — deployment justification (ticket, release note, etc.)
    - confirm — explicit "deploy" confirmation string

  ▎ Workflows flagged as ambiguous had their push trigger commented out rather than removed, preserving the original configuration for review.

### How to Deploy to Production

  Go to Actions → [workflow name] → Run workflow, fill in both inputs, and trigger manually.

### Why

  Automatic production deploys on push introduce risk of unintended releases. Manual dispatch enforces a deliberate, auditable deployment step.

### Related

  Part of a cross-repo initiative to gate all production deployments behind manual approval.