### PR TITLE
fix: stop sending unnecessary payload

### DIFF
--- a/app/listeners/webhook_listener.rb
+++ b/app/listeners/webhook_listener.rb
@@ -138,6 +138,7 @@ class WebhookListener < BaseListener
       return false if message_payload_unusable?(payload)
     when 'message_updated'
       return false unless payload[:content_type] == 'input_select'
+      return false unless input_select_submitted?(payload)
     when 'conversation_created'
       return false
     when 'conversation_updated'
@@ -147,6 +148,11 @@ class WebhookListener < BaseListener
     end
 
     true
+  end
+
+  def input_select_submitted?(payload)
+    submitted_values = payload.dig(:content_attributes, 'submitted_values')
+    submitted_values.is_a?(Array) && submitted_values.any? { |sv| sv['value'].present? }
   end
 
   def message_payload_unusable?(payload)


### PR DESCRIPTION
## Description
Previously, a PR was made to stop sending payloads not used by nane and generating errors in nane's conversation listener (#165), but we had a non-identified case with a problematic payload when the user interacts with quick replies.
This PR aims to stop sending this problematic payload to nane's conversation listener, which contains the information of the quick replies' options, but not the option that the candidate selected.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
- Interacting with a staging bot that executes a complex flow that uses quick replies.
- Answering the bot with the quick replies' buttons.
- Checking the conversation listener logs - there are no payloads that have only the options and not the user answer.
- Searching for errors in all log groups that contain "Invalid webhook URL" - there are no recent errors.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
