### PR TITLE
fix: session isolation for widget with referral

### DIFF
--- a/app/javascript/entrypoints/sdk.js
+++ b/app/javascript/entrypoints/sdk.js
@@ -1,6 +1,10 @@
 import Cookies from 'js-cookie';
 import { IFrameHelper } from '../sdk/IFrameHelper';
 import {
+  resolveReferralForSDK,
+  removeConversationAuthToken,
+} from '../sdk/conversationAuthStorage';
+import {
   getBubbleView,
   getDarkMode,
   getWidgetStyle,
@@ -54,8 +58,12 @@ const runSDK = ({ baseUrl, websiteToken, referral }) => {
     locale = window.navigator.language.replace('-', '_');
   }
 
+  const resolvedReferral = resolveReferralForSDK(referral);
+  const useSessionStorageForConversation = resolvedReferral.length > 0;
+
   window.$chatwoot = {
-    referral: referral,
+    referral: resolvedReferral || undefined,
+    useSessionStorageForConversation,
     baseUrl,
     baseDomain,
     hasLoaded: false,
@@ -107,7 +115,7 @@ const runSDK = ({ baseUrl, websiteToken, referral }) => {
         baseUrl: window.$chatwoot.baseUrl,
         websiteToken: window.$chatwoot.websiteToken,
         locale,
-        referral,
+        referral: window.$chatwoot.referral,
       });
     },
 
@@ -199,7 +207,10 @@ const runSDK = ({ baseUrl, websiteToken, referral }) => {
         IFrameHelper.events.toggleBubble();
       }
 
-      Cookies.remove('cw_conversation');
+      removeConversationAuthToken(
+        window.$chatwoot.websiteToken,
+        window.$chatwoot.useSessionStorageForConversation
+      );
       Cookies.remove(getUserCookieName());
 
       const iframe = IFrameHelper.getAppFrame();
@@ -216,7 +227,7 @@ const runSDK = ({ baseUrl, websiteToken, referral }) => {
   IFrameHelper.createFrame({
     baseUrl,
     websiteToken,
-    referral,
+    referral: resolvedReferral || undefined,
   });
 };
 

--- a/app/javascript/sdk/IFrameHelper.js
+++ b/app/javascript/sdk/IFrameHelper.js
@@ -37,12 +37,17 @@ import { isFlatWidgetStyle } from './settingsHelper';
 import { popoutChatWindow } from '../widget/helpers/popoutHelper';
 import { openFullScreenWindow } from '../widget/helpers/fullscreenHelper';
 import addHours from 'date-fns/addHours';
+import {
+  getConversationAuthToken,
+  setConversationAuthToken,
+} from './conversationAuthStorage';
 
-const updateAuthCookie = (cookieContent, websiteToken) => {
-  Cookies.set(`cw_conversation_${websiteToken}`, cookieContent, {
-    expires: 365,
-    sameSite: 'Lax',
-  });
+const persistConversationAuthToken = (token, websiteToken) => {
+  setConversationAuthToken(
+    websiteToken,
+    token,
+    window.$chatwoot.useSessionStorageForConversation
+  );
 };
 
 const updateCampaignReadStatus = baseDomain => {
@@ -57,7 +62,7 @@ export const IFrameHelper = {
   getUrl({ baseUrl, websiteToken, referral }) {
     let ref = '';
     if (referral) {
-      ref = `&referral=${referral}`;
+      ref = `&referral=${encodeURIComponent(referral)}`;
     }
     return `${baseUrl}/widget?website_token=${websiteToken}${ref}`;
   },
@@ -68,10 +73,13 @@ export const IFrameHelper = {
 
     loadCSS();
     const iframe = document.createElement('iframe');
-    const cwCookie = Cookies.get(`cw_conversation_${websiteToken}`);
+    const authToken = getConversationAuthToken(
+      websiteToken,
+      window.$chatwoot.useSessionStorageForConversation
+    );
     let widgetUrl = IFrameHelper.getUrl({ baseUrl, websiteToken, referral });
-    if (cwCookie) {
-      widgetUrl = `${widgetUrl}&cw_conversation=${cwCookie}`;
+    if (authToken) {
+      widgetUrl = `${widgetUrl}&cw_conversation=${encodeURIComponent(authToken)}`;
     }
     iframe.src = widgetUrl;
     iframe.allow =
@@ -161,7 +169,10 @@ export const IFrameHelper = {
 
   events: {
     loaded: message => {
-      updateAuthCookie(message.config.authToken, window.$chatwoot.websiteToken);
+      persistConversationAuthToken(
+        message.config.authToken,
+        window.$chatwoot.websiteToken
+      );
       window.$chatwoot.hasLoaded = true;
       const campaignsSnoozedTill = Cookies.get('cw_snooze_campaigns_till');
       IFrameHelper.sendMessage('config-set', {
@@ -208,7 +219,10 @@ export const IFrameHelper = {
     },
 
     setAuthCookie({ data: { widgetAuthToken } }) {
-      updateAuthCookie(widgetAuthToken, window.$chatwoot.websiteToken);
+      persistConversationAuthToken(
+        widgetAuthToken,
+        window.$chatwoot.websiteToken
+      );
     },
 
     setCampaignReadOn() {
@@ -234,15 +248,21 @@ export const IFrameHelper = {
     },
 
     popoutChatWindow: ({ baseUrl, websiteToken, locale }) => {
-      const cwCookie = Cookies.get(`cw_conversation_${websiteToken}`);
+      const authToken = getConversationAuthToken(
+        websiteToken,
+        window.$chatwoot.useSessionStorageForConversation
+      );
       window.$chatwoot.toggle('close');
-      popoutChatWindow(baseUrl, websiteToken, locale, cwCookie);
+      popoutChatWindow(baseUrl, websiteToken, locale, authToken);
     },
 
     openFullScreenWindow: ({ baseUrl, websiteToken, locale, referral }) => {
-      const cwCookie = Cookies.get(`cw_conversation_${websiteToken}`);
+      const authToken = getConversationAuthToken(
+        websiteToken,
+        window.$chatwoot.useSessionStorageForConversation
+      );
       window.$chatwoot.toggle('close');
-      openFullScreenWindow(baseUrl, websiteToken, locale, referral, cwCookie);
+      openFullScreenWindow(baseUrl, websiteToken, locale, referral, authToken);
     },
 
     closeWindow: () => {

--- a/app/javascript/sdk/conversationAuthStorage.js
+++ b/app/javascript/sdk/conversationAuthStorage.js
@@ -1,0 +1,64 @@
+import Cookies from 'js-cookie';
+
+const conversationKey = websiteToken => `cw_conversation_${websiteToken}`;
+
+/**
+ * Referral from run({ referral }) or, if omitted, from the host page ?referral=.
+ * Non-empty referral enables sessionStorage (one conversation per browser tab).
+ */
+export const resolveReferralForSDK = explicitReferral => {
+  const explicit =
+    explicitReferral == null ? '' : String(explicitReferral).trim();
+  if (explicit) return explicit;
+  try {
+    const fromUrl = new URLSearchParams(window.location.search).get(
+      'referral'
+    );
+    return fromUrl && String(fromUrl).trim() ? String(fromUrl).trim() : '';
+  } catch {
+    return '';
+  }
+};
+
+export const getConversationAuthToken = (websiteToken, useSession) => {
+  const key = conversationKey(websiteToken);
+  if (useSession) {
+    try {
+      return window.sessionStorage.getItem(key) || undefined;
+    } catch {
+      return undefined;
+    }
+  }
+  return Cookies.get(key);
+};
+
+export const setConversationAuthToken = (websiteToken, token, useSession) => {
+  const key = conversationKey(websiteToken);
+  if (useSession) {
+    try {
+      window.sessionStorage.setItem(key, token);
+    } catch {
+      // sessionStorage may be unavailable; token still works for current load via iframe
+    }
+    Cookies.remove(key);
+  } else {
+    Cookies.set(key, token, {
+      expires: 365,
+      sameSite: 'Lax',
+    });
+  }
+};
+
+export const removeConversationAuthToken = (websiteToken, useSession) => {
+  const key = conversationKey(websiteToken);
+  if (useSession) {
+    try {
+      window.sessionStorage.removeItem(key);
+    } catch {
+      // ignore
+    }
+  } else {
+    Cookies.remove(key);
+  }
+  Cookies.remove('cw_conversation');
+};

--- a/app/javascript/sdk/conversationAuthStorage.js
+++ b/app/javascript/sdk/conversationAuthStorage.js
@@ -11,9 +11,7 @@ export const resolveReferralForSDK = explicitReferral => {
     explicitReferral == null ? '' : String(explicitReferral).trim();
   if (explicit) return explicit;
   try {
-    const fromUrl = new URLSearchParams(window.location.search).get(
-      'referral'
-    );
+    const fromUrl = new URLSearchParams(window.location.search).get('referral');
     return fromUrl && String(fromUrl).trim() ? String(fromUrl).trim() : '';
   } catch {
     return '';

--- a/app/javascript/widget/views/Home.vue
+++ b/app/javascript/widget/views/Home.vue
@@ -21,7 +21,7 @@ export default {
   methods: {
     startConversation() {
       const ref = new URLSearchParams(window.location.search).get('referral');
-      if (ref) {
+      if (ref && !this.conversationSize) {
         this.$store.dispatch('conversation/createConversation', {});
       }
       if (this.preChatFormEnabled && !this.conversationSize) {


### PR DESCRIPTION
## Description

When a referral is provided—either in the SDK script configuration or as a query parameter on the page URL—the widget stores the conversation token in session storage; when no referral is set, it keeps using a cookie as before.

**Context.** We often saw two problems: after a **page reload**, the bot flow restarted and the **welcome message** was sent again even though **older messages** were still visible, so anything the visitor had already shared felt lost and they had to start from scratch. Also, **several browser tabs** used the **same** conversation, so what happened in one tab showed up in the others.

**Before**
Messages used to mix across tabs because the cw_conversation cookie is shared for the whole browser profile. Whatever happened in one tab showed up in the others.


<img width="1720" height="1042" alt="Screenshot 2026-06-11 at 11 19 35 AM" src="https://github.com/user-attachments/assets/2a1d0a02-0c52-41b9-8489-58d74d6fbf03" />

**After**
Each tab can have **its own chat**. **What you do in one tab does not show up in another tab** the same way as before.


<img width="1720" height="1040" alt="Screenshot 2026-06-11 at 11 16 43 AM" src="https://github.com/user-attachments/assets/6aa46dcf-db57-4e81-806f-c91113914982" />




## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Manual testing was done across several scenarios using a test matrix to cover each case.


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
