### PR TITLE
feat: make customer_id required for website and API channels

### DIFF
--- a/app/controllers/api/v1/accounts/inboxes_controller.rb
+++ b/app/controllers/api/v1/accounts/inboxes_controller.rb
@@ -1,8 +1,12 @@
 class Api::V1::Accounts::InboxesController < Api::V1::Accounts::BaseController
   include Api::V1::InboxesHelper
+
+  CUSTOMER_ID_REQUIRED_CHANNELS = %w[web_widget api].freeze
+
   before_action :fetch_inbox, except: [:index, :create]
   before_action :fetch_agent_bot, only: [:set_agent_bot]
   before_action :validate_limit, only: [:create]
+  before_action :validate_customer_id, only: [:create]
   # we are already handling the authorization in fetch inbox
   before_action :check_authorization, except: [:show]
 
@@ -78,6 +82,14 @@ class Api::V1::Accounts::InboxesController < Api::V1::Accounts::BaseController
 
   def fetch_agent_bot
     @agent_bot = AgentBot.find(params[:agent_bot]) if params[:agent_bot]
+  end
+
+  def validate_customer_id
+    return unless CUSTOMER_ID_REQUIRED_CHANNELS.include?(permitted_params.dig(:channel, :type))
+    return if permitted_params[:customer_id].present?
+
+    render json: { message: I18n.t('messages.inbox_customer_id_required'), attributes: ['customer_id'] },
+           status: :unprocessable_entity
   end
 
   def create_channel

--- a/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
@@ -424,7 +424,8 @@
       "CUSTOMER_ID": {
         "LABEL": "Customer ID",
         "PLACEHOLDER": "Enter customer ID",
-        "HELP_TEXT": "This ID will be included in webhook payloads for this inbox"
+        "HELP_TEXT": "This ID will be included in webhook payloads for this inbox",
+        "ERROR": "Customer ID is required"
       },
       "SENDER_NAME_SECTION": {
         "TITLE": "Sender name",

--- a/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
@@ -424,7 +424,6 @@
       "CUSTOMER_ID": {
         "LABEL": "Customer ID",
         "PLACEHOLDER": "Enter customer ID",
-        "HELP_TEXT": "This ID will be included in webhook payloads for this inbox",
         "ERROR": "Customer ID is required"
       },
       "SENDER_NAME_SECTION": {

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
@@ -449,7 +449,6 @@ export default {
             class="pb-4"
             :label="$t('INBOX_MGMT.EDIT.CUSTOMER_ID.LABEL')"
             :placeholder="$t('INBOX_MGMT.EDIT.CUSTOMER_ID.PLACEHOLDER')"
-            :help-text="$t('INBOX_MGMT.EDIT.CUSTOMER_ID.HELP_TEXT')"
           />
           <woot-input
             v-if="isAPIInbox"

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Api.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Api.vue
@@ -22,6 +22,7 @@ export default {
     return {
       channelName: '',
       webhookUrl: '',
+      customerId: '',
     };
   },
   computed: {
@@ -32,6 +33,7 @@ export default {
   validations: {
     channelName: { required },
     webhookUrl: { shouldBeWebhookUrl },
+    customerId: { required },
   },
   methods: {
     async createChannel() {
@@ -43,6 +45,7 @@ export default {
       try {
         const apiChannel = await this.$store.dispatch('inboxes/createChannel', {
           name: this.channelName,
+          customer_id: this.customerId,
           channel: {
             type: 'api',
             webhook_url: this.webhookUrl,
@@ -91,6 +94,24 @@ export default {
             $t('INBOX_MGMT.ADD.API_CHANNEL.CHANNEL_NAME.ERROR')
           }}</span>
         </label>
+      </div>
+
+      <div class="flex-shrink-0 flex-grow-0">
+        <label :class="{ error: v$.customerId.$error }">
+          {{ $t('INBOX_MGMT.EDIT.CUSTOMER_ID.LABEL') }}
+          <input
+            v-model="customerId"
+            type="text"
+            :placeholder="$t('INBOX_MGMT.EDIT.CUSTOMER_ID.PLACEHOLDER')"
+            @blur="v$.customerId.$touch"
+          />
+          <span v-if="v$.customerId.$error" class="message">{{
+            $t('INBOX_MGMT.EDIT.CUSTOMER_ID.ERROR')
+          }}</span>
+        </label>
+        <p class="help-text">
+          {{ $t('INBOX_MGMT.EDIT.CUSTOMER_ID.HELP_TEXT') }}
+        </p>
       </div>
 
       <div class="flex-shrink-0 flex-grow-0">

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Api.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Api.vue
@@ -109,9 +109,6 @@ export default {
             $t('INBOX_MGMT.EDIT.CUSTOMER_ID.ERROR')
           }}</span>
         </label>
-        <p class="help-text">
-          {{ $t('INBOX_MGMT.EDIT.CUSTOMER_ID.HELP_TEXT') }}
-        </p>
       </div>
 
       <div class="flex-shrink-0 flex-grow-0">

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Website.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Website.vue
@@ -115,9 +115,6 @@ export default {
             :placeholder="$t('INBOX_MGMT.EDIT.CUSTOMER_ID.PLACEHOLDER')"
           />
         </label>
-        <p class="help-text">
-          {{ $t('INBOX_MGMT.EDIT.CUSTOMER_ID.HELP_TEXT') }}
-        </p>
       </div>
       <div class="w-full">
         <label>

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Website.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Website.vue
@@ -18,6 +18,7 @@ export default {
   data() {
     return {
       inboxName: '',
+      customerId: '',
       channelWebsiteUrl: '',
       channelWidgetColor: '#009CE0',
       channelWelcomeTitle: '',
@@ -48,6 +49,7 @@ export default {
           'inboxes/createWebsiteChannel',
           {
             name: this.inboxName,
+            customer_id: this.customerId,
             greeting_enabled: this.greetingEnabled,
             greeting_message: this.greetingMessage,
             channel: {
@@ -103,6 +105,19 @@ export default {
             :placeholder="$t('INBOX_MGMT.ADD.WEBSITE_NAME.PLACEHOLDER')"
           />
         </label>
+      </div>
+      <div class="w-full">
+        <label>
+          {{ $t('INBOX_MGMT.EDIT.CUSTOMER_ID.LABEL') }}
+          <input
+            v-model="customerId"
+            type="text"
+            :placeholder="$t('INBOX_MGMT.EDIT.CUSTOMER_ID.PLACEHOLDER')"
+          />
+        </label>
+        <p class="help-text">
+          {{ $t('INBOX_MGMT.EDIT.CUSTOMER_ID.HELP_TEXT') }}
+        </p>
       </div>
       <div class="w-full">
         <label>
@@ -198,7 +213,7 @@ export default {
           <NextButton
             type="submit"
             :is-loading="uiFlags.isCreating"
-            :disabled="!channelWebsiteUrl || !inboxName"
+            :disabled="!channelWebsiteUrl || !inboxName || !customerId.trim()"
             solid
             blue
             :label="$t('INBOX_MGMT.ADD.WEBSITE_CHANNEL.SUBMIT_BUTTON')"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,6 +35,7 @@ en:
     reset_password_success: Woot! Request for password reset is successful. Check your mail for instructions.
     reset_password_failure: Uh ho! We could not find any user with the specified email.
     inbox_deletetion_response: Your inbox deletion request will be processed in some time.
+    inbox_customer_id_required: Customer ID is required to create this inbox.
 
   errors:
     validations:

--- a/spec/controllers/api/v1/accounts/inboxes_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/inboxes_controller_spec.rb
@@ -363,7 +363,7 @@ RSpec.describe 'Inboxes API', type: :request do
 
     context 'when it is an authenticated user' do
       let(:admin) { create(:user, account: account, role: :administrator) }
-      let(:valid_params) { { name: 'test', channel: { type: 'web_widget', website_url: 'test.com' } } }
+      let(:valid_params) { { name: 'test', customer_id: 'cust-123', channel: { type: 'web_widget', website_url: 'test.com' } } }
 
       it 'will not create inbox for agent' do
         agent = create(:user, account: account, role: :agent)
@@ -386,6 +386,31 @@ RSpec.describe 'Inboxes API', type: :request do
         expect(response.body).to include('test.com')
       end
 
+      it 'does not create a webwidget inbox without customer_id' do
+        expect do
+          post "/api/v1/accounts/#{account.id}/inboxes",
+               headers: admin.create_new_auth_token,
+               params: { name: 'test', channel: { type: 'web_widget', website_url: 'test.com' } },
+               as: :json
+        end.to not_change(Inbox, :count).and(not_change(Channel::WebWidget, :count))
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['message']).to eq('Customer ID is required to create this inbox.')
+        expect(response.parsed_body['attributes']).to eq(['customer_id'])
+      end
+
+      it 'does not create an api inbox when customer_id is only whitespace' do
+        expect do
+          post "/api/v1/accounts/#{account.id}/inboxes",
+               headers: admin.create_new_auth_token,
+               params: { name: 'API Inbox', customer_id: '   ', channel: { type: 'api', webhook_url: 'http://test.com' } },
+               as: :json
+        end.to not_change(Inbox, :count)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['message']).to eq('Customer ID is required to create this inbox.')
+      end
+
       it 'creates a email inbox when administrator' do
         post "/api/v1/accounts/#{account.id}/inboxes",
              headers: admin.create_new_auth_token,
@@ -396,10 +421,21 @@ RSpec.describe 'Inboxes API', type: :request do
         expect(response.body).to include('test@test.com')
       end
 
+      it 'creates an inbox for a channel that does not require customer_id' do
+        expect do
+          post "/api/v1/accounts/#{account.id}/inboxes",
+               headers: admin.create_new_auth_token,
+               params: { name: 'test', channel: { type: 'email', email: 'no-customer-id@test.com' } },
+               as: :json
+        end.to change(Inbox, :count).by(1)
+
+        expect(response).to have_http_status(:success)
+      end
+
       it 'creates an api inbox when administrator' do
         post "/api/v1/accounts/#{account.id}/inboxes",
              headers: admin.create_new_auth_token,
-             params: { name: 'API Inbox', channel: { type: 'api', webhook_url: 'http://test.com' } },
+             params: { name: 'API Inbox', customer_id: 'cust-123', channel: { type: 'api', webhook_url: 'http://test.com' } },
              as: :json
 
         expect(response).to have_http_status(:success)


### PR DESCRIPTION
## Description
Adds `customer_id` as a required field when creating inboxes of type Website or API, both in the UI (Website and Api creation forms) and via direct API requests. The field remains optional at the model/database level to avoid breaking existing inboxes and other channel types. Validation returns a 422 with a clear error message and prevents the channel from being created when `customer_id` is missing or blank. Other channels (email, SMS, Telegram, etc.) are unaffected.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

### Website
1. Create a new inbox (Website or API type).
2. Write inbox data.
3. "Create inbox" button should only be enabled if the Customer ID field has data.

https://github.com/user-attachments/assets/cf464d8f-9023-4ef8-b934-b4462c665dcd

### HTTP/API Request
1. Send request to create inbox for the desired account.
   - If the request doesn't contain `customer_id` field, the request should be rejected and return corresponding error.
   - If the request contains `customer_id` field, an inbox should be created.


https://github.com/user-attachments/assets/3e73941c-7ee0-4c94-9090-551dee041ba7



## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules